### PR TITLE
Use Universal Module Definition

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   output: {
     filename: 'raunch-webbluetooth.js',
     path: path.resolve(__dirname, 'dist'),
-    library: "RaunchWebBluetooth"
+    library: "RaunchWebBluetooth",
+    libraryTarget: "umd"
   }
 };


### PR DESCRIPTION
I had a hard time using the library with the [rollup.js](https://rollupjs.org/) bundler since it only exported a global variable. Using UMD makes it easier to import into various bundling schemes.